### PR TITLE
Add verify_SSL=>1 to HTTP::Tiny to verify https server identity

### DIFF
--- a/lib/Finance/Robinhood.pm
+++ b/lib/Finance/Robinhood.pm
@@ -163,6 +163,7 @@ official app and use the C<internal> scope with full access.
         isa     => InstanceOf ['HTTP::Tiny'],
         default => sub ($s) {
             HTTP::Tiny->new(
+                verify_SSL => 1,
                 agent =>
                     sprintf( 'Perl/%s (%s) %s/%s', ( $^V =~ m[([\.\d]+)] ), $^O, ref $s, $VERSION ),
                 default_headers => {


### PR DESCRIPTION
The `verify_SSL=>1` flag is missing from HTTP::Tiny, and could allow a network attacker to MITM https connections made by this distribution.

I'm not a Robinhood user, so unable to verify or test.

For more context see: https://hackeriet.github.io/cpan-http-tiny-overview/